### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/1124632362/459f9ff3-d641-492b-92b2-d8739b4522a6/a4782bf6-0af1-4d06-9d7e-c46a02eaa236/_apis/work/boardbadge/92179b8f-1ae5-44d9-b3b0-88cdb82c6692)](https://dev.azure.com/1124632362/459f9ff3-d641-492b-92b2-d8739b4522a6/_boards/board/t/a4782bf6-0af1-4d06-9d7e-c46a02eaa236/Microsoft.RequirementCategory)
 # blog_image
 blog_image


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/1124632362/459f9ff3-d641-492b-92b2-d8739b4522a6/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.